### PR TITLE
Store backups in "directories", by date

### DIFF
--- a/src/Api.cs
+++ b/src/Api.cs
@@ -139,8 +139,10 @@ namespace ms_continuus
             var paddedVolume = volume.ToString();
             if (volume < 10) paddedVolume = "0" + paddedVolume;
             Directory.CreateDirectory("./tmp");
+            // '%2F' is used to encode /. That way we do not need to deal with creating all necessary folders,
+            // in order to have the same structure in Azure 
             var fileName =
-                $"./tmp/archive-{DateTime.Now:dd_MM_yyyy}-vol.{paddedVolume}-{migrationId.ToString()}.tar.gz";
+                $"./tmp/{DateTime.Now:dd_MM_yyyy}%2Fvol.{paddedVolume}-{migrationId}.tar.gz";
             SetPreviewHeader();
             Console.WriteLine($"Downloading archive {migrationId}");
             var attempts = 1;

--- a/src/BlobStorage.cs
+++ b/src/BlobStorage.cs
@@ -48,7 +48,7 @@ namespace ms_continuus
             var timeStarted = DateTime.Now;
             const int retryInterval = 30_000;
             var attempts = 1;
-            var fileName = Path.GetFileName(filePath);
+            var fileName = Path.GetFileName(filePath)?.Replace("%2F", "/");
             var blobClient = _containerClient.GetBlobClient(fileName);
             var metadata = new Dictionary<string, string>();
 


### PR DESCRIPTION
Closes #4.
In Azure, there are no true folders, but virtual ones, based on `/` in the blob's name.

---

Draft: Open to suggestions on where blobs are stored, and whether the "hash" with `%2F` (the URL encoded version of `/`) is ok.