### PR TITLE
Exclude large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ms-continuus is configured entirely with environment variables.
   |YEARLY_RETENTION:|420|Delete blobs with retentionClass='yearly' older than n-days|
   |GITHUB_TOKEN:|null|Required: Github Personal Access Token|
   |STORAGE_ACCOUNT_CON_STRING:|null|Required: Azure StorageAccount ConnectionString|
+  |EXCLUDE_LARGE_FILES:|true|Exclude attachments and release assets from the migration archive to reduce file size|
 
 ## (TODO: Waiting for Blob Idex Tags Preview Feature)
 

--- a/src/Api.cs
+++ b/src/Api.cs
@@ -187,7 +187,12 @@ namespace ms_continuus
 
         public async Task<Migration> StartMigration(List<string> repositoryList)
         {
-            var payload = $"{{\"repositories\": {JsonConvert.SerializeObject(repositoryList)}}}";
+            var payload = JsonConvert.SerializeObject(new
+            {
+                repositories = repositoryList,
+                exclude_attachments = Config.ExcludeLargeFiles,
+                exclude_releases = Config.ExcludeLargeFiles
+            });
             SetPreviewHeader();
             var response = await Client.PostAsync(_migrationsUrl, new StringContent(payload));
             response.EnsureSuccessStatusCode();

--- a/src/BlobStorage.cs
+++ b/src/BlobStorage.cs
@@ -129,10 +129,10 @@ namespace ms_continuus
         public async Task UploadManifest(
             List<string> allRepositories,
             List<(string archivePath, int migrationId, int volume, List<string> repositories)> uploadedVolumes,
-            List<(List<string> repositories, int volume)> failedVolumes)
+            List<(List<string> repositories, int volume)> failedVolumes,
+            string runDate)
         {
-            var today = $"{DateTime.Now:yyyy_MM_dd}";
-            var manifestBlobName = $"{today}/manifest.json";
+            var manifestBlobName = $"{runDate}/manifest.json";
             var blobClient = _containerClient.GetBlobClient(manifestBlobName);
 
             var manifest = new

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -45,6 +45,8 @@ namespace ms_continuus
 
             StorageAccountConnectionString = Environment.GetEnvironmentVariable("STORAGE_ACCOUNT_CON_STRING");
             if (StorageAccountConnectionString == null) throw new Exception("Environment variable 'STORAGE_ACCOUNT_CON_STRING' missing");
+
+            ExcludeLargeFiles = Environment.GetEnvironmentVariable("EXCLUDE_LARGE_FILES")?.ToLower() != "false";
         }
 
         public string Organization { get; }
@@ -56,6 +58,7 @@ namespace ms_continuus
         public int YearlyRetention { get; }
         public string GithubToken { get; }
         public string StorageAccountConnectionString { get; }
+        public bool ExcludeLargeFiles { get; }
 
         public override string ToString()
         {
@@ -66,8 +69,9 @@ namespace ms_continuus
             var weekRet = $"\n\tWEEKLY_RETENTION: {WeeklyRetention}";
             var monthRet = $"\n\tMONTHLY_RETENTION: {MonthlyRetention}";
             var yearRet = $"\n\tYEARLY_RETENTION: {YearlyRetention}";
+            var exclLargeFiles = $"\n\tEXCLUDE_LARGE_FILES: {ExcludeLargeFiles}";
 
-            return "Configuration settings:" + ghUrl + org + container + tag + weekRet + monthRet + yearRet;
+            return "Configuration settings:" + ghUrl + org + container + tag + weekRet + monthRet + yearRet + exclLargeFiles;
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -58,7 +58,7 @@ namespace ms_continuus
             return archivePath;
         }
 
-        private static async Task BackupArchive()
+        private static async Task BackupArchive(string runDate)
         {
             // Each migration can contain approx. 100~120 repositories
             // to keep the API from timing out. This also makes sense for retrying
@@ -148,7 +148,7 @@ namespace ms_continuus
             var failedForManifest = failedToMigrate2
                 .Select(kvp => (kvp.Value.Item1, kvp.Value.Item2))
                 .ToList();
-            await BlobStorage.UploadManifest(allRepositoryList, uploadedForManifest, failedForManifest);
+            await BlobStorage.UploadManifest(allRepositoryList, uploadedForManifest, failedForManifest, runDate);
         }
 
         private static async Task Main(string[] args)
@@ -158,7 +158,7 @@ namespace ms_continuus
             Console.WriteLine("Starting backup of Github organization");
             var startTime = DateTime.Now;
             await BlobStorage.EnsureContainer();
-            await BackupArchive();
+            await BackupArchive($"{startTime:yyyy_MM_dd}");
             await DeleteWeeklyBlobs();
             await DeleteMonthlyBlobs();
             await DeleteYearlyBlobs();


### PR DESCRIPTION
This pull request introduces a new feature to optionally exclude large files (attachments and release assets) from migration archives to reduce file size, controlled by an environment variable. It also improves how manifests are named by making the run date explicit, and updates related configuration and documentation.

**Large file exclusion feature:**

* Added a new environment variable, `EXCLUDE_LARGE_FILES`, to control whether attachments and release assets are excluded from migration archives. This is now documented in the `README.md`.
* Updated the migration API payload to include `exclude_attachments` and `exclude_releases` fields based on the configuration.

**Manifest and backup process improvements:**

* Changed the manifest upload process to use an explicit `runDate` for naming, improving traceability of backup runs. This affects both the manifest file naming and the backup orchestration logic.